### PR TITLE
[DS-117] Add Google Tag code to Doc Site

### DIFF
--- a/11ty/src/_includes/layouts/base.njk
+++ b/11ty/src/_includes/layouts/base.njk
@@ -7,6 +7,15 @@
     <title>
       {{ title }} | {{ meta.siteName }}
     </title>
+    <!-- Google Tag Manager -->
+    <script>
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-KMFGVLX');
+    </script>
+    <!-- End Google Tag Manager -->
     <!-- Open Graph -->
     <meta property="og:title" content="{{ title }}"/>
     <meta property="og:type" content="website"/>
@@ -29,6 +38,11 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KMFGVLX" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <section aria-label="Skip links" class="skip-links">
       <div class="viewport-container">
         <ul>


### PR DESCRIPTION
# Overview
Google Tag Manager has been set up in the admin, and now needs to be added to the website. This pull requests adds the generated code that will allow us to control GA4 events.

## Screenshots
![Tag Assistant in lower right corner](https://user-images.githubusercontent.com/27687379/199303787-9a2e37cc-0552-426c-ac1d-ffc950dbc48f.png)
*Tag Assistant showing up in lower-right corner of window.*

![GTM Summary preview](https://user-images.githubusercontent.com/27687379/199303834-0c2779a7-0d65-4240-b2d5-f000ac29d25a.png)
*Preview of test trigger being fired in GTM dashboard.*