### PR TITLE
Override height in reset, alert, and pagination styles

### DIFF
--- a/11ty/src/_data/alert.json
+++ b/11ty/src/_data/alert.json
@@ -1,12 +1,12 @@
 {
   "info": {
-  "active": true,
+  "active": false,
   "icon":  "info",
   "message": "The site is currently in development."
   },
   "warning": {
-    "active": false,
+    "active": true,
     "icon": "warning",
-    "message": "The site is currently experiencing issues."
+    "message": "The site is currently in development."
     }
 }

--- a/11ty/src/_data/tokens.json
+++ b/11ty/src/_data/tokens.json
@@ -1,0 +1,1232 @@
+{
+  "color": {
+    "blue": {
+      "100": {
+        "value": "rgb(247, 248, 249)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#F7F8F9"
+        },
+        "name": "color-blue-100",
+        "attributes": {
+          "category": "color",
+          "type": "blue",
+          "item": "100"
+        },
+        "path": [
+          "color",
+          "blue",
+          "100"
+        ]
+      },
+      "200": {
+        "value": "rgb(178, 190, 201)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#B2BEC9"
+        },
+        "name": "color-blue-200",
+        "attributes": {
+          "category": "color",
+          "type": "blue",
+          "item": "200"
+        },
+        "path": [
+          "color",
+          "blue",
+          "200"
+        ]
+      },
+      "300": {
+        "value": "rgb(76, 103, 129)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#4C6781"
+        },
+        "name": "color-blue-300",
+        "attributes": {
+          "category": "color",
+          "type": "blue",
+          "item": "300"
+        },
+        "path": [
+          "color",
+          "blue",
+          "300"
+        ]
+      },
+      "400": {
+        "value": "rgb(0, 39, 76)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#00274C"
+        },
+        "name": "color-blue-400",
+        "attributes": {
+          "category": "color",
+          "type": "blue",
+          "item": "400"
+        },
+        "path": [
+          "color",
+          "blue",
+          "400"
+        ]
+      },
+      "500": {
+        "value": "rgb(0, 19, 36)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#001324"
+        },
+        "name": "color-blue-500",
+        "attributes": {
+          "category": "color",
+          "type": "blue",
+          "item": "500"
+        },
+        "path": [
+          "color",
+          "blue",
+          "500"
+        ]
+      }
+    },
+    "maize": {
+      "100": {
+        "value": "rgb(255, 249, 230)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#FFF9E6"
+        },
+        "name": "color-maize-100",
+        "attributes": {
+          "category": "color",
+          "type": "maize",
+          "item": "100"
+        },
+        "path": [
+          "color",
+          "maize",
+          "100"
+        ]
+      },
+      "200": {
+        "value": "rgb(255, 234, 155)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#FFEA9B"
+        },
+        "name": "color-maize-200",
+        "attributes": {
+          "category": "color",
+          "type": "maize",
+          "item": "200"
+        },
+        "path": [
+          "color",
+          "maize",
+          "200"
+        ]
+      },
+      "300": {
+        "value": "rgb(255, 218, 80)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#FFDA50"
+        },
+        "name": "color-maize-300",
+        "attributes": {
+          "category": "color",
+          "type": "maize",
+          "item": "300"
+        },
+        "path": [
+          "color",
+          "maize",
+          "300"
+        ]
+      },
+      "400": {
+        "value": "rgb(255, 203, 5)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#FFCB05"
+        },
+        "name": "color-maize-400",
+        "attributes": {
+          "category": "color",
+          "type": "maize",
+          "item": "400"
+        },
+        "path": [
+          "color",
+          "maize",
+          "400"
+        ]
+      },
+      "500": {
+        "value": "rgb(234, 186, 2)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#EABA02"
+        },
+        "name": "color-maize-500",
+        "attributes": {
+          "category": "color",
+          "type": "maize",
+          "item": "500"
+        },
+        "path": [
+          "color",
+          "maize",
+          "500"
+        ]
+      }
+    },
+    "neutral": {
+      "100": {
+        "value": "rgb(229, 233, 237)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#E5E9ED"
+        },
+        "name": "color-neutral-100",
+        "attributes": {
+          "category": "color",
+          "type": "neutral",
+          "item": "100"
+        },
+        "path": [
+          "color",
+          "neutral",
+          "100"
+        ]
+      },
+      "200": {
+        "value": "rgb(138, 150, 161)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#8A96A1"
+        },
+        "name": "color-neutral-200",
+        "attributes": {
+          "category": "color",
+          "type": "neutral",
+          "item": "200"
+        },
+        "path": [
+          "color",
+          "neutral",
+          "200"
+        ]
+      },
+      "300": {
+        "value": "rgb(99, 115, 129)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#637381"
+        },
+        "name": "color-neutral-300",
+        "attributes": {
+          "category": "color",
+          "type": "neutral",
+          "item": "300"
+        },
+        "path": [
+          "color",
+          "neutral",
+          "300"
+        ]
+      },
+      "400": {
+        "value": "rgb(33, 43, 54)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#212B36"
+        },
+        "name": "color-neutral-400",
+        "attributes": {
+          "category": "color",
+          "type": "neutral",
+          "item": "400"
+        },
+        "path": [
+          "color",
+          "neutral",
+          "400"
+        ]
+      },
+      "500": {
+        "value": "rgb(6, 8, 10)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#06080A"
+        },
+        "name": "color-neutral-500",
+        "attributes": {
+          "category": "color",
+          "type": "neutral",
+          "item": "500"
+        },
+        "path": [
+          "color",
+          "neutral",
+          "500"
+        ]
+      }
+    },
+    "teal": {
+      "100": {
+        "value": "rgb(233, 242, 245)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#E9F2F5"
+        },
+        "name": "color-teal-100",
+        "attributes": {
+          "category": "color",
+          "type": "teal",
+          "item": "100"
+        },
+        "path": [
+          "color",
+          "teal",
+          "100"
+        ]
+      },
+      "200": {
+        "value": "rgb(167, 205, 219)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#A7CDDB"
+        },
+        "name": "color-teal-200",
+        "attributes": {
+          "category": "color",
+          "type": "teal",
+          "item": "200"
+        },
+        "path": [
+          "color",
+          "teal",
+          "200"
+        ]
+      },
+      "300": {
+        "value": "rgb(101, 168, 191)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#65A8BF"
+        },
+        "name": "color-teal-300",
+        "attributes": {
+          "category": "color",
+          "type": "teal",
+          "item": "300"
+        },
+        "path": [
+          "color",
+          "teal",
+          "300"
+        ]
+      },
+      "400": {
+        "value": "rgb(29, 116, 145)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#1D7491"
+        },
+        "name": "color-teal-400",
+        "attributes": {
+          "category": "color",
+          "type": "teal",
+          "item": "400"
+        },
+        "path": [
+          "color",
+          "teal",
+          "400"
+        ]
+      },
+      "500": {
+        "value": "rgb(16, 102, 132)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#106684"
+        },
+        "name": "color-teal-500",
+        "attributes": {
+          "category": "color",
+          "type": "teal",
+          "item": "500"
+        },
+        "path": [
+          "color",
+          "teal",
+          "500"
+        ]
+      }
+    },
+    "orange": {
+      "100": {
+        "value": "rgb(255, 241, 235)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#FFF1EB"
+        },
+        "name": "color-orange-100",
+        "attributes": {
+          "category": "color",
+          "type": "orange",
+          "item": "100"
+        },
+        "path": [
+          "color",
+          "orange",
+          "100"
+        ]
+      },
+      "200": {
+        "value": "rgb(255, 184, 153)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#FFB899"
+        },
+        "name": "color-orange-200",
+        "attributes": {
+          "category": "color",
+          "type": "orange",
+          "item": "200"
+        },
+        "path": [
+          "color",
+          "orange",
+          "200"
+        ]
+      },
+      "300": {
+        "value": "rgb(255, 138, 88)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#FF8A58"
+        },
+        "name": "color-orange-300",
+        "attributes": {
+          "category": "color",
+          "type": "orange",
+          "item": "300"
+        },
+        "path": [
+          "color",
+          "orange",
+          "300"
+        ]
+      },
+      "400": {
+        "value": "rgb(242, 95, 31)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#F25F1F"
+        },
+        "name": "color-orange-400",
+        "attributes": {
+          "category": "color",
+          "type": "orange",
+          "item": "400"
+        },
+        "path": [
+          "color",
+          "orange",
+          "400"
+        ]
+      },
+      "500": {
+        "value": "rgb(199, 78, 26)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#C74E1A"
+        },
+        "name": "color-orange-500",
+        "attributes": {
+          "category": "color",
+          "type": "orange",
+          "item": "500"
+        },
+        "path": [
+          "color",
+          "orange",
+          "500"
+        ]
+      }
+    },
+    "pink": {
+      "100": {
+        "value": "rgb(252, 235, 235)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#FCEBEB"
+        },
+        "name": "color-pink-100",
+        "attributes": {
+          "category": "color",
+          "type": "pink",
+          "item": "100"
+        },
+        "path": [
+          "color",
+          "pink",
+          "100"
+        ]
+      },
+      "200": {
+        "value": "rgb(242, 157, 157)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#F29D9D"
+        },
+        "name": "color-pink-200",
+        "attributes": {
+          "category": "color",
+          "type": "pink",
+          "item": "200"
+        },
+        "path": [
+          "color",
+          "pink",
+          "200"
+        ]
+      },
+      "300": {
+        "value": "rgb(236, 105, 105)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#EC6969"
+        },
+        "name": "color-pink-300",
+        "attributes": {
+          "category": "color",
+          "type": "pink",
+          "item": "300"
+        },
+        "path": [
+          "color",
+          "pink",
+          "300"
+        ]
+      },
+      "400": {
+        "value": "rgb(217, 56, 56)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#D93838"
+        },
+        "name": "color-pink-400",
+        "attributes": {
+          "category": "color",
+          "type": "pink",
+          "item": "400"
+        },
+        "path": [
+          "color",
+          "pink",
+          "400"
+        ]
+      },
+      "500": {
+        "value": "rgb(191, 50, 50)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#BF3232"
+        },
+        "name": "color-pink-500",
+        "attributes": {
+          "category": "color",
+          "type": "pink",
+          "item": "500"
+        },
+        "path": [
+          "color",
+          "pink",
+          "500"
+        ]
+      }
+    },
+    "indigo": {
+      "100": {
+        "value": "rgb(238, 241, 249)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#EEF1F9"
+        },
+        "name": "color-indigo-100",
+        "attributes": {
+          "category": "color",
+          "type": "indigo",
+          "item": "100"
+        },
+        "path": [
+          "color",
+          "indigo",
+          "100"
+        ]
+      },
+      "200": {
+        "value": "rgb(170, 185, 227)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#AAB9E3"
+        },
+        "name": "color-indigo-200",
+        "attributes": {
+          "category": "color",
+          "type": "indigo",
+          "item": "200"
+        },
+        "path": [
+          "color",
+          "indigo",
+          "200"
+        ]
+      },
+      "300": {
+        "value": "rgb(124, 147, 212)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#7C93D4"
+        },
+        "name": "color-indigo-300",
+        "attributes": {
+          "category": "color",
+          "type": "indigo",
+          "item": "300"
+        },
+        "path": [
+          "color",
+          "indigo",
+          "300"
+        ]
+      },
+      "400": {
+        "value": "rgb(80, 111, 197)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#506FC5"
+        },
+        "name": "color-indigo-400",
+        "attributes": {
+          "category": "color",
+          "type": "indigo",
+          "item": "400"
+        },
+        "path": [
+          "color",
+          "indigo",
+          "400"
+        ]
+      },
+      "500": {
+        "value": "rgb(39, 67, 145)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#274391"
+        },
+        "name": "color-indigo-500",
+        "attributes": {
+          "category": "color",
+          "type": "indigo",
+          "item": "500"
+        },
+        "path": [
+          "color",
+          "indigo",
+          "500"
+        ]
+      }
+    },
+    "green": {
+      "100": {
+        "value": "rgb(234, 248, 238)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#EAF8EE"
+        },
+        "name": "color-green-100",
+        "attributes": {
+          "category": "color",
+          "type": "green",
+          "item": "100"
+        },
+        "path": [
+          "color",
+          "green",
+          "100"
+        ]
+      },
+      "200": {
+        "value": "rgb(150, 219, 170)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#96DBAA"
+        },
+        "name": "color-green-200",
+        "attributes": {
+          "category": "color",
+          "type": "green",
+          "item": "200"
+        },
+        "path": [
+          "color",
+          "green",
+          "200"
+        ]
+      },
+      "300": {
+        "value": "rgb(87, 188, 117)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#57BC75"
+        },
+        "name": "color-green-300",
+        "attributes": {
+          "category": "color",
+          "type": "green",
+          "item": "300"
+        },
+        "path": [
+          "color",
+          "green",
+          "300"
+        ]
+      },
+      "400": {
+        "value": "rgb(32, 168, 72)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#20A848"
+        },
+        "name": "color-green-400",
+        "attributes": {
+          "category": "color",
+          "type": "green",
+          "item": "400"
+        },
+        "path": [
+          "color",
+          "green",
+          "400"
+        ]
+      },
+      "500": {
+        "value": "rgb(25, 133, 57)",
+        "filePath": "src/tokens/color/colors.json",
+        "isSource": true,
+        "original": {
+          "value": "#198539"
+        },
+        "name": "color-green-500",
+        "attributes": {
+          "category": "color",
+          "type": "green",
+          "item": "500"
+        },
+        "path": [
+          "color",
+          "green",
+          "500"
+        ]
+      }
+    }
+  },
+  "font": {
+    "base": {
+      "family": {
+        "value": "'Mulish', sans-serif",
+        "filePath": "src/tokens/font/font.json",
+        "isSource": true,
+        "original": {
+          "value": "'Mulish', sans-serif"
+        },
+        "name": "font-base-family",
+        "attributes": {
+          "category": "font",
+          "type": "base",
+          "item": "family"
+        },
+        "path": [
+          "font",
+          "base",
+          "family"
+        ]
+      }
+    },
+    "second": {
+      "family": {
+        "value": "'Crimson Text', serif",
+        "filePath": "src/tokens/font/font.json",
+        "isSource": true,
+        "original": {
+          "value": "'Crimson Text', serif"
+        },
+        "name": "font-second-family",
+        "attributes": {
+          "category": "font",
+          "type": "second",
+          "item": "family"
+        },
+        "path": [
+          "font",
+          "second",
+          "family"
+        ]
+      }
+    }
+  },
+  "regular": {
+    "value": 400,
+    "filePath": "src/tokens/font/weight.json",
+    "isSource": true,
+    "original": {
+      "value": 400
+    },
+    "name": "regular",
+    "attributes": {
+      "category": "regular"
+    },
+    "path": [
+      "regular"
+    ]
+  },
+  "semibold": {
+    "value": 600,
+    "filePath": "src/tokens/font/weight.json",
+    "isSource": true,
+    "original": {
+      "value": 600
+    },
+    "name": "semibold",
+    "attributes": {
+      "category": "semibold"
+    },
+    "path": [
+      "semibold"
+    ]
+  },
+  "bold": {
+    "value": 700,
+    "filePath": "src/tokens/font/weight.json",
+    "isSource": true,
+    "original": {
+      "value": 700
+    },
+    "name": "bold",
+    "attributes": {
+      "category": "bold"
+    },
+    "path": [
+      "bold"
+    ]
+  },
+  "extrabold": {
+    "value": 800,
+    "filePath": "src/tokens/font/weight.json",
+    "isSource": true,
+    "original": {
+      "value": 800
+    },
+    "name": "extrabold",
+    "attributes": {
+      "category": "extrabold"
+    },
+    "path": [
+      "extrabold"
+    ]
+  },
+  "opacity": {
+    "30": {
+      "value": "0.30",
+      "filePath": "src/tokens/opacity.json",
+      "isSource": true,
+      "original": {
+        "value": "0.30"
+      },
+      "name": "opacity-30",
+      "attributes": {
+        "category": "opacity",
+        "type": "30"
+      },
+      "path": [
+        "opacity",
+        "30"
+      ]
+    },
+    "50": {
+      "value": "0.50",
+      "filePath": "src/tokens/opacity.json",
+      "isSource": true,
+      "original": {
+        "value": "0.50"
+      },
+      "name": "opacity-50",
+      "attributes": {
+        "category": "opacity",
+        "type": "50"
+      },
+      "path": [
+        "opacity",
+        "50"
+      ]
+    },
+    "75": {
+      "value": "0.75",
+      "filePath": "src/tokens/opacity.json",
+      "isSource": true,
+      "original": {
+        "value": "0.75"
+      },
+      "name": "opacity-75",
+      "attributes": {
+        "category": "opacity",
+        "type": "75"
+      },
+      "path": [
+        "opacity",
+        "75"
+      ]
+    }
+  },
+  "line-height": {
+    "default": {
+      "value": "1.5",
+      "filePath": "src/tokens/size/line-height.json",
+      "isSource": true,
+      "original": {
+        "value": "1.5"
+      },
+      "name": "line-height-default",
+      "attributes": {
+        "category": "line-height",
+        "type": "default"
+      },
+      "path": [
+        "line-height",
+        "default"
+      ]
+    },
+    "heading": {
+      "value": "1.25",
+      "filePath": "src/tokens/size/line-height.json",
+      "isSource": true,
+      "original": {
+        "value": "1.25"
+      },
+      "name": "line-height-heading",
+      "attributes": {
+        "category": "line-height",
+        "type": "heading"
+      },
+      "path": [
+        "line-height",
+        "heading"
+      ]
+    },
+    "page-heading": {
+      "value": "1.125",
+      "filePath": "src/tokens/size/line-height.json",
+      "isSource": true,
+      "original": {
+        "value": "1.125"
+      },
+      "name": "line-height-page-heading",
+      "attributes": {
+        "category": "line-height",
+        "type": "page-heading"
+      },
+      "path": [
+        "line-height",
+        "page-heading"
+      ]
+    }
+  },
+  "radius": {
+    "default": {
+      "value": "4px",
+      "filePath": "src/tokens/size/size.json",
+      "isSource": true,
+      "original": {
+        "value": "4px"
+      },
+      "name": "radius-default",
+      "attributes": {
+        "category": "radius",
+        "type": "default"
+      },
+      "path": [
+        "radius",
+        "default"
+      ]
+    }
+  },
+  "line-length": {
+    "value": "60ch",
+    "filePath": "src/tokens/size/size.json",
+    "isSource": true,
+    "original": {
+      "value": "60ch"
+    },
+    "name": "line-length",
+    "attributes": {
+      "category": "line-length"
+    },
+    "path": [
+      "line-length"
+    ]
+  },
+  "z-space": {
+    "small": {
+      "value": "rgba(0, 0, 0, 0.2) 0px 2px 8px 0px",
+      "filePath": "src/tokens/size/spacing.json",
+      "isSource": true,
+      "original": {
+        "value": "rgba(0, 0, 0, 0.2) 0px 2px 8px 0px"
+      },
+      "name": "z-space-small",
+      "attributes": {
+        "category": "z-space",
+        "type": "small"
+      },
+      "path": [
+        "z-space",
+        "small"
+      ]
+    },
+    "medium": {
+      "value": "rgba(0, 0, 0, 0.2) 0px 2px 16px 0px",
+      "filePath": "src/tokens/size/spacing.json",
+      "isSource": true,
+      "original": {
+        "value": "rgba(0, 0, 0, 0.2) 0px 2px 16px 0px"
+      },
+      "name": "z-space-medium",
+      "attributes": {
+        "category": "z-space",
+        "type": "medium"
+      },
+      "path": [
+        "z-space",
+        "medium"
+      ]
+    }
+  },
+  "text": {
+    "base-size": {
+      "value": "16px",
+      "filePath": "src/tokens/size/text.json",
+      "isSource": true,
+      "original": {
+        "value": "16px"
+      },
+      "name": "text-base-size",
+      "attributes": {
+        "category": "text",
+        "type": "base-size"
+      },
+      "path": [
+        "text",
+        "base-size"
+      ]
+    },
+    "xxx-large": {
+      "value": "3.5rem",
+      "filePath": "src/tokens/size/text.json",
+      "isSource": true,
+      "original": {
+        "value": "3.5rem"
+      },
+      "name": "text-xxx-large",
+      "attributes": {
+        "category": "text",
+        "type": "xxx-large"
+      },
+      "path": [
+        "text",
+        "xxx-large"
+      ]
+    },
+    "xx-large": {
+      "value": "2.25rem",
+      "filePath": "src/tokens/size/text.json",
+      "isSource": true,
+      "original": {
+        "value": "2.25rem"
+      },
+      "name": "text-xx-large",
+      "attributes": {
+        "category": "text",
+        "type": "xx-large"
+      },
+      "path": [
+        "text",
+        "xx-large"
+      ]
+    },
+    "x-large": {
+      "value": "2rem",
+      "filePath": "src/tokens/size/text.json",
+      "isSource": true,
+      "original": {
+        "value": "2rem"
+      },
+      "name": "text-x-large",
+      "attributes": {
+        "category": "text",
+        "type": "x-large"
+      },
+      "path": [
+        "text",
+        "x-large"
+      ]
+    },
+    "large": {
+      "value": "1.75rem",
+      "filePath": "src/tokens/size/text.json",
+      "isSource": true,
+      "original": {
+        "value": "1.75rem"
+      },
+      "name": "text-large",
+      "attributes": {
+        "category": "text",
+        "type": "large"
+      },
+      "path": [
+        "text",
+        "large"
+      ]
+    },
+    "medium": {
+      "value": "1.5rem",
+      "filePath": "src/tokens/size/text.json",
+      "isSource": true,
+      "original": {
+        "value": "1.5rem"
+      },
+      "name": "text-medium",
+      "attributes": {
+        "category": "text",
+        "type": "medium"
+      },
+      "path": [
+        "text",
+        "medium"
+      ]
+    },
+    "small": {
+      "value": "1.25rem",
+      "filePath": "src/tokens/size/text.json",
+      "isSource": true,
+      "original": {
+        "value": "1.25rem"
+      },
+      "name": "text-small",
+      "attributes": {
+        "category": "text",
+        "type": "small"
+      },
+      "path": [
+        "text",
+        "small"
+      ]
+    },
+    "x-small": {
+      "value": "1.125rem",
+      "filePath": "src/tokens/size/text.json",
+      "isSource": true,
+      "original": {
+        "value": "1.125rem"
+      },
+      "name": "text-x-small",
+      "attributes": {
+        "category": "text",
+        "type": "x-small"
+      },
+      "path": [
+        "text",
+        "x-small"
+      ]
+    },
+    "xx-small": {
+      "value": "1rem",
+      "filePath": "src/tokens/size/text.json",
+      "isSource": true,
+      "original": {
+        "value": "1rem"
+      },
+      "name": "text-xx-small",
+      "attributes": {
+        "category": "text",
+        "type": "xx-small"
+      },
+      "path": [
+        "text",
+        "xx-small"
+      ]
+    },
+    "xxx-small": {
+      "value": "0.875rem",
+      "filePath": "src/tokens/size/text.json",
+      "isSource": true,
+      "original": {
+        "value": "0.875rem"
+      },
+      "name": "text-xxx-small",
+      "attributes": {
+        "category": "text",
+        "type": "xxx-small"
+      },
+      "path": [
+        "text",
+        "xxx-small"
+      ]
+    }
+  }
+}

--- a/11ty/src/_includes/layouts/base.njk
+++ b/11ty/src/_includes/layouts/base.njk
@@ -53,10 +53,10 @@
     </section>
     <div class="headers">
       <m-universal-header></m-universal-header>
+      {% include "partials/alert.njk" %}
       <m-website-header name=" {{ meta.productName }}"></m-website-header>
       {% include "partials/primary-nav.njk" %}
     </div>
-    {% include "partials/alert.njk" %}
     <main class="layout" id="main">
       {{ content | safe }}
     </main>

--- a/11ty/src/scss/_alert.scss
+++ b/11ty/src/scss/_alert.scss
@@ -20,7 +20,12 @@
 .alert__container {
   display: flex;
   align-items: center;
+  padding: 8px 0;
+  .material-icons {
+    font-size: 1rem;
+  }
   p {
-    padding-left: .25rem;
+    padding-left: .5rem;
+    margin: 0;
   }
 }

--- a/11ty/src/scss/_pagination.scss
+++ b/11ty/src/scss/_pagination.scss
@@ -12,7 +12,7 @@
 
   .line {
     border: solid 1px var(--color-neutral-100);
-    width: 80%;
+    width: 50%;
   }
 
   .back-to-top {
@@ -32,10 +32,10 @@
 .pagination-text {
   margin-left: 1rem;
   font-weight: bold;
-  max-width: 22ch;
+  max-width: 65ch;
   h2 {
     color: var(--color-teal-500);
-    font-size: 1.25rem;
+    font-size: 1.125rem;
     margin-bottom: .5rem;
   }
   a {

--- a/11ty/src/scss/_reset.scss
+++ b/11ty/src/scss/_reset.scss
@@ -47,7 +47,7 @@ html {
 
 /* Set core body defaults */
 body {
-  min-height: 100vh;
+  height: revert !important;
   font-family: sans-serif;
   font-size: 100%;
   line-height: 1.5;


### PR DESCRIPTION
## What's new

- Fixing the recurring `height` issue from umich lib css.
- Moved alert partial below UH and changed the type
- Some styling for alert and pagination
- Added `tokens.json` for color table shenanigans 