### PR TITLE
Styles for prose headings and tables

### DIFF
--- a/11ty/src/scss/_base.scss
+++ b/11ty/src/scss/_base.scss
@@ -19,6 +19,19 @@ h1 {
   padding-bottom: 1rem;
 }
 
+.prose h2, 
+.prose h3, 
+.prose h4 {
+  margin-top: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.prose h5, 
+.prose h6 {
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
 .headers {
   border-bottom: solid 2px var(--color-neutral-100);
 }
@@ -80,7 +93,7 @@ code {
 
 blockquote {
   padding: .25rem 1rem;
-  border-left: solid 4px var(--color-indigo-300);
+  border-left: solid 4px var(--color-neutral-300);
   color: var(--color-neutral-300);
   font-weight: var(--semibold);
   font-size: 1rem;

--- a/11ty/src/scss/_breadcrumbs.scss
+++ b/11ty/src/scss/_breadcrumbs.scss
@@ -57,8 +57,10 @@
   font-size: 1rem;
 }
 
+/*
 @media screen and (max-width: 768px) {
   .breadcrumbs li:not(:last-child) {
   display: none;
   }
 }
+*/

--- a/11ty/src/scss/_tables.scss
+++ b/11ty/src/scss/_tables.scss
@@ -1,0 +1,45 @@
+// --------------------------------------------------
+//
+// # Tables
+// 
+// --------------------------------------------------
+
+table {
+  width: 100% !important;
+  border: 0 !important; 
+  border-collapse: collapse !important;
+}
+
+thead {
+  border-color: transparent;
+}
+
+tr > * {
+  border-bottom: solid 1px var(--color-neutral-100);
+  padding: 1rem 0;
+  vertical-align: top;
+}
+
+tr > *:not(:last-child) {
+  padding-right: 2rem;
+}
+
+td, th {
+  padding: 1rem;
+  padding-left: 0;
+  vertical-align: top;
+}
+
+th {
+  text-align: left;
+  border-bottom: solid 2px var(--color-maize-400);
+  font-size: .875rem;
+  font-weight: 800;
+  letter-spacing: 1.25px;
+  text-transform: uppercase;
+  vertical-align: middle;
+}
+
+th:not([scope^='row']) {
+  border-bottom: solid var(--space-xxx-small) var(--color-maize-400);
+}

--- a/11ty/src/scss/style.scss
+++ b/11ty/src/scss/style.scss
@@ -13,3 +13,4 @@
 @use 'alert';
 @use 'codepen';
 @use 'docs-color-block';
+@use 'tables';


### PR DESCRIPTION
## What's new

- Added some beginning styles for `table`
- Removed media query for breadcrumbs as team needs to re-review breadcrumb in small viewport
- Added some margin for headings in post (`.prose`) content