### PR TITLE
sort by title as well as weight

### DIFF
--- a/11ty/src/_data/drupal.js
+++ b/11ty/src/_data/drupal.js
@@ -176,7 +176,9 @@ module.exports = async function () {
     let childMenuItems = menuDataIndex.filter((link) => {
       return (menuData[link].parent == parentLink );
     })
-    childMenuItems.sort((a, b) => { return menuData[a].weight - menuData[b].weight });
+    childMenuItems.sort((a, b) => { 
+      return menuData[a].title.localeCompare(menuData[b].title) || (menuData[a].weight - menuData[b].weight)  
+    });
     childMenuItems.forEach((link) => {
       let pageItem = pageData[link];
       retval[pageItem.tags].push(pageItem);


### PR DESCRIPTION
Menu sort was only taking into account `weight` which left equal weights pretty random.

This adds a title comparison.