### PR TITLE
Add block text callout style for theme

### DIFF
--- a/src/scss/_callouts.scss
+++ b/src/scss/_callouts.scss
@@ -121,7 +121,8 @@
 
 .umich-lib-callout,
 .umich-lib-print, 
-.umich-lib-alert {
+.umich-lib-alert, 
+.umich-lib-block-text  {
   margin: 1rem 0;
   padding: 1rem;
   border: solid 1px #E5E9ED;
@@ -157,4 +158,10 @@
     float:left;
     height: 80px;
     }
+}
+
+.umich-lib-block-text {
+  border-left: solid 4px transparent;
+  border: solid 1px transparent;
+  margin-left: 2rem;
 }


### PR DESCRIPTION
## What's new

There is a new callout style `block-text` in the DS admin theme that needed styling on the docs side. CSS only change.