### PR TITLE
Add tabindex to code blocks so they can be scrolled with kb

### DIFF
--- a/lib/transforms/docs-color-block.js
+++ b/lib/transforms/docs-color-block.js
@@ -36,6 +36,7 @@ module.exports = function (el) {
       // add a class to the `<pre>` tag for easier styling
       // could remove once we're convinced we can rely on pre:has(code)
       el.parentElement.classList.add('code');
+      el.setAttribute("tabindex", "0");
     }
   }
 }

--- a/lib/transforms/docs-color-block.js
+++ b/lib/transforms/docs-color-block.js
@@ -37,7 +37,7 @@ module.exports = function (el) {
       // could remove once we're convinced we can rely on pre:has(code)
       el.parentElement.classList.add('code');
       el.setAttribute("tabindex", "0");
-      el.setAttribute("role", "group");
+      el.setAttribute("role", "figure");
       el.setAttribute("aria-label", "Code to be copied");
     }
   }

--- a/lib/transforms/docs-color-block.js
+++ b/lib/transforms/docs-color-block.js
@@ -37,6 +37,8 @@ module.exports = function (el) {
       // could remove once we're convinced we can rely on pre:has(code)
       el.parentElement.classList.add('code');
       el.setAttribute("tabindex", "0");
+      el.setAttribute("role", "group");
+      el.setAttribute("aria-label", "Code to be copied");
     }
   }
 }


### PR DESCRIPTION
# What's new

Problem: Scrollable code blocks are not accessible to keyboard users. General advice is: "tabindex="0" should be applied to any non-interactive element that has had CSS’ overflow property applied to it."

## Solution

- Add `tabindex="0"` to code blocks so keyboard users can focus on and scroll if there is scrollable content. They still get focus even if they aren't scrollable but didn't want to add too many conditionals. We can adjust later if we add a lot more code blocks and it creates too many tab stops. 
- Add name via an aria-label and a `role="group"` to satisfy alerts from ARC Toolkit. If there is just tabindex, there are alerts/errors for focus in a non-interactice element. I used a group role as opposed to a region role because it is most likely not important enough to include in the page structure as a region.

This is an experimental fix. Tested with VoiceOver.

<img width="850" alt="code blocks have visual focus and are keyboard focusable" src="https://github.com/mlibrary/design-system-docs/assets/29953622/95303a2f-e182-466e-b52f-a448da67d276">
